### PR TITLE
Improve performance for `Affix`

### DIFF
--- a/src/affix.rs
+++ b/src/affix.rs
@@ -354,7 +354,7 @@ where
             Self::allocation_layout(layout).unwrap(),
             Self::unchecked_allocation_layout(layout)
         );
-        
+
         let (prefix_offset, layout, _) = Self::unchecked_allocation_layout(layout);
         let base_ptr = ptr.as_ptr().sub(prefix_offset);
         self.parent

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(
     allocator_api,
     alloc_layout_extra,
+    const_checked_int_methods,
     const_alloc_layout,
     const_fn,
     const_generics,


### PR DESCRIPTION
Makes large parts of `Affix` a `const fn` so passing a compile time `Layout` can almost optimize away completely the affix calculation. For `Prefix` and `Suffix` being a ZST this results in the same assembly as if you would left `Affix` out completely.

Additionally, the `Suffix` alignment does not realign the whole memory block resulting in smaller memory footprints.